### PR TITLE
Fix mail server port conflict: pin PORT=3001 in PM2 config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -28,11 +28,10 @@ rm -rf build
 mv "$BUILD_TMP" build
 
 echo "==> [5/5] Mail sunucusu yeniden başlatılıyor..."
-if pm2 describe ozguruzden-server > /dev/null 2>&1; then
-    pm2 restart ozguruzden-server
-else
-    pm2 start ecosystem.config.js --env production
-fi
+# startOrRestart, ecosystem.config.js'i her seferinde yeniden okur;
+# böylece port/env değişiklikleri restart'ta kaybolmaz
+pm2 startOrRestart ecosystem.config.js --env production
+pm2 save
 
 # Artık kullanılmayan AI sunucusu hâlâ kayıtlıysa kaldır
 if pm2 describe ai-server > /dev/null 2>&1; then

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,8 +3,13 @@ module.exports = {
     {
       name: "ozguruzden-server",
       script: "/var/www/ozguruzden.com/server/server.js",
+      cwd: "/var/www/ozguruzden.com",
+      env: {
+        PORT: 3001
+      },
       env_production: {
-        NODE_ENV: "production"
+        NODE_ENV: "production",
+        PORT: 3001
       },
       instances: 1,
       exec_mode: "fork",


### PR DESCRIPTION
ozguruzden-server crashed with EADDRINUSE because it inherited PORT=3000 from the server's root .env. Pin PORT=3001 and cwd in ecosystem.config.js, and use pm2 startOrRestart in deploy.sh so config changes are re-read on every deploy.